### PR TITLE
Fix Skill-related combat bugs

### DIFF
--- a/character/character.go
+++ b/character/character.go
@@ -215,6 +215,10 @@ func (ch *Character) GetCmbSkill() *skills.Skill {
   return ch.CmbSkill
 }
 
+func (ch *Character) ClearCmbSkill() {
+  ch.CmbSkill = nil
+}
+
 func (ch *Character) GetSpawn() interfaces.RoomI {
   return ch.Spawn
 }

--- a/character/character.go
+++ b/character/character.go
@@ -2,6 +2,7 @@ package character
 
 import (
   "math"
+  "sync"
 
   "github.com/joelevering/gomud/classes"
   "github.com/joelevering/gomud/interfaces"
@@ -29,6 +30,7 @@ type Character struct {
   Sag        int               `json:"sagacity"`
   InCombat   bool
   CmbSkill   *skills.Skill
+  CmbSkillMu sync.Mutex
   Spawn      interfaces.RoomI
 }
 
@@ -215,8 +217,22 @@ func (ch *Character) GetCmbSkill() *skills.Skill {
   return ch.CmbSkill
 }
 
+func (ch *Character) LockCmbSkill() {
+  ch.CmbSkillMu.Lock()
+}
+
+func (ch *Character) UnlockCmbSkill() {
+  ch.CmbSkillMu.Unlock()
+}
+
+func (ch *Character) SetCmbSkill(sk *skills.Skill) {
+  ch.CmbSkillMu.Lock()
+  ch.CmbSkill = sk
+  ch.CmbSkillMu.Unlock()
+}
+
 func (ch *Character) ClearCmbSkill() {
-  ch.CmbSkill = nil
+  ch.SetCmbSkill(nil)
 }
 
 func (ch *Character) GetSpawn() interfaces.RoomI {

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -108,6 +108,7 @@ type CharI interface {
   GetAtk() int
   GetDef() int
   GetCmbSkill() *skills.Skill
+  ClearCmbSkill()
   GetLevel() int
   GetExp() int
   GetExpGiven() int

--- a/interfaces/interfaces.go
+++ b/interfaces/interfaces.go
@@ -108,7 +108,10 @@ type CharI interface {
   GetAtk() int
   GetDef() int
   GetCmbSkill() *skills.Skill
+  SetCmbSkill(*skills.Skill)
   ClearCmbSkill()
+  LockCmbSkill()
+  UnlockCmbSkill()
   GetLevel() int
   GetExp() int
   GetExpGiven() int

--- a/mocks/mock_character.go
+++ b/mocks/mock_character.go
@@ -9,20 +9,21 @@ type MockCharacter struct {
   Spawn      interfaces.RoomI
   InCombat   bool
 
-  Atk           int
-  Def           int
-  CmbSkill      *skills.Skill
-  SetDetArg     int
-  SetMaxDetArg  int
-  SetStrArg     int
-  SetFloArg     int
-  LeveledUp     bool
-  LeftCombat    bool
-  EnteredCombat bool
-  Healed        bool
-  ExpGained     int
-  ShouldLevelUp bool
-  ShouldDie     bool
+  Atk             int
+  Def             int
+  CmbSkill        *skills.Skill
+  SetDetArg       int
+  SetMaxDetArg    int
+  SetStrArg       int
+  SetFloArg       int
+  LeveledUp       bool
+  LeftCombat      bool
+  EnteredCombat   bool
+  Healed          bool
+  ExpGained       int
+  ShouldLevelUp   bool
+  ShouldDie       bool
+  ClearedCmbSkill bool
 }
 
 func (m *MockCharacter) GetClassName() string { return "Superstar" }
@@ -59,6 +60,7 @@ func (m *MockCharacter) SetSag(sag int) {}
 func (m *MockCharacter) GetAtk() int { return m.Atk }
 func (m *MockCharacter) GetDef() int { return m.Def }
 func (m *MockCharacter) GetCmbSkill() *skills.Skill { return m.CmbSkill }
+func (m *MockCharacter) ClearCmbSkill() { m.ClearedCmbSkill = true }
 func (m *MockCharacter) GetLevel() int { return 2 }
 func (m *MockCharacter) GetExp() int { return 0 }
 func (m *MockCharacter) GetExpGiven() int { return 2 }

--- a/mocks/mock_character.go
+++ b/mocks/mock_character.go
@@ -9,21 +9,23 @@ type MockCharacter struct {
   Spawn      interfaces.RoomI
   InCombat   bool
 
-  Atk             int
-  Def             int
-  CmbSkill        *skills.Skill
-  SetDetArg       int
-  SetMaxDetArg    int
-  SetStrArg       int
-  SetFloArg       int
-  LeveledUp       bool
-  LeftCombat      bool
-  EnteredCombat   bool
-  Healed          bool
-  ExpGained       int
-  ShouldLevelUp   bool
-  ShouldDie       bool
-  ClearedCmbSkill bool
+  Atk              int
+  Def              int
+  CmbSkill         *skills.Skill
+  SetDetArg        int
+  SetMaxDetArg     int
+  SetStrArg        int
+  SetFloArg        int
+  LeveledUp        bool
+  LeftCombat       bool
+  EnteredCombat    bool
+  Healed           bool
+  ExpGained        int
+  ShouldLevelUp    bool
+  ShouldDie        bool
+  ClearedCmbSkill  bool
+  LockedCmbSkill   bool
+  UnlockedCmbSkill bool
 }
 
 func (m *MockCharacter) GetClassName() string { return "Superstar" }
@@ -60,7 +62,10 @@ func (m *MockCharacter) SetSag(sag int) {}
 func (m *MockCharacter) GetAtk() int { return m.Atk }
 func (m *MockCharacter) GetDef() int { return m.Def }
 func (m *MockCharacter) GetCmbSkill() *skills.Skill { return m.CmbSkill }
+func (m *MockCharacter) SetCmbSkill(*skills.Skill) {}
 func (m *MockCharacter) ClearCmbSkill() { m.ClearedCmbSkill = true }
+func (m *MockCharacter) LockCmbSkill() { m.LockedCmbSkill = true }
+func (m *MockCharacter) UnlockCmbSkill() { m.UnlockedCmbSkill = true }
 func (m *MockCharacter) GetLevel() int { return 2 }
 func (m *MockCharacter) GetExp() int { return 0 }
 func (m *MockCharacter) GetExpGiven() int { return 2 }

--- a/player/combat.go
+++ b/player/combat.go
@@ -37,12 +37,27 @@ func (ci *CombatInstance) Start() {
   }
 }
 
-func (ci *CombatInstance) Loop(report bool) (combatOver bool) {
-  defer ci.pc.ClearCmbSkill()
-  defer ci.npc.ClearCmbSkill()
+func (ci *CombatInstance) getSkills() (pcSk, npcSk *skills.Skill) {
+  ci.pc.LockCmbSkill()
+  ci.npc.LockCmbSkill()
 
-  pcResults := ci.getPCResults()
-  npcResults := ci.getNPCResults()
+  return ci.pc.GetCmbSkill(), ci.npc.GetCmbSkill()
+}
+
+func (ci *CombatInstance) clearSkills() {
+  ci.pc.UnlockCmbSkill()
+  ci.pc.ClearCmbSkill() // Low probability race condition
+
+  ci.npc.UnlockCmbSkill()
+  ci.npc.ClearCmbSkill()
+}
+
+func (ci *CombatInstance) Loop(report bool) (combatOver bool) {
+  pcSk, npcSk := ci.getSkills()
+  defer ci.clearSkills()
+
+  pcResults := ci.getPCResults(pcSk)
+  npcResults := ci.getNPCResults(npcSk)
 
   npcDmg := pcResults.npcDmg + npcResults.npcDmg
   pcDmg := pcResults.pcDmg + npcResults.pcDmg
@@ -68,9 +83,8 @@ func (ci *CombatInstance) Loop(report bool) (combatOver bool) {
   return false
 }
 
-func (ci *CombatInstance) getPCResults() *CombatResults {
+func (ci *CombatInstance) getPCResults(sk *skills.Skill) *CombatResults {
   res := &CombatResults{}
-  sk := ci.pc.GetCmbSkill()
 
   if sk == nil {
     res.npcDmg = CalcAtkDmg(ci.pc.GetAtk(), ci.npc.GetDef())
@@ -96,7 +110,7 @@ func (ci *CombatInstance) getPCResults() *CombatResults {
   return res
 }
 
-func (ci *CombatInstance) getNPCResults() *CombatResults {
+func (ci *CombatInstance) getNPCResults(_ *skills.Skill) *CombatResults {
   return &CombatResults{
     pcDmg: CalcAtkDmg(ci.npc.GetAtk(), ci.pc.GetDef()),
   }

--- a/player/combat.go
+++ b/player/combat.go
@@ -38,6 +38,9 @@ func (ci *CombatInstance) Start() {
 }
 
 func (ci *CombatInstance) Loop(report bool) (combatOver bool) {
+  defer ci.pc.ClearCmbSkill()
+  defer ci.npc.ClearCmbSkill()
+
   pcResults := ci.getPCResults()
   npcResults := ci.getNPCResults()
 

--- a/player/combat_test.go
+++ b/player/combat_test.go
@@ -35,6 +35,14 @@ func Test_LoopDealsDamage(t *testing.T) {
   if !pc.ClearedCmbSkill || !npc.ClearedCmbSkill {
     t.Error("Expected both PC and NPC combat skills to be cleared on loop, but they weren't")
   }
+
+  if !pc.LockedCmbSkill || !pc.UnlockedCmbSkill {
+    t.Error("Expected PC combat skills to be locked and then unlocked in a CI loop")
+  }
+
+  if !npc.LockedCmbSkill || !npc.UnlockedCmbSkill {
+    t.Error("Expected NPC combat skills to be locked and then unlocked in a CI loop")
+  }
 }
 
 func Test_PCDefeat(t *testing.T) {

--- a/player/combat_test.go
+++ b/player/combat_test.go
@@ -32,6 +32,9 @@ func Test_LoopDealsDamage(t *testing.T) {
   if npc.SetDetArg != 102 {
     t.Errorf("Expected npc to go down from 150 to 102 damage but it went down to %d", npc.SetDetArg)
   }
+  if !pc.ClearedCmbSkill || !npc.ClearedCmbSkill {
+    t.Error("Expected both PC and NPC combat skills to be cleared on loop, but they weren't")
+  }
 }
 
 func Test_PCDefeat(t *testing.T) {
@@ -52,6 +55,10 @@ func Test_PCDefeat(t *testing.T) {
 
   if !pc.LeftCombat {
     t.Error("Expected PC to leave combat on defeat, but it did not")
+  }
+
+  if !pc.ClearedCmbSkill || !npc.ClearedCmbSkill {
+    t.Error("Expected both PC and NPC combat skills to be cleared on PC defeat, but they weren't")
   }
 }
 
@@ -78,5 +85,9 @@ func Test_NPCDefeat(t *testing.T) {
 
   if !pc.LeftCombat {
     t.Error("Expected PC to leave combat on win, but it didn't")
+  }
+
+  if !pc.ClearedCmbSkill || !npc.ClearedCmbSkill {
+    t.Error("Expected both PC and NPC combat skills to be cleared on NPC defeat, but they weren't")
   }
 }

--- a/player/player.go
+++ b/player/player.go
@@ -74,7 +74,7 @@ func (p *Player) Cmd(cmd string) {
   if p.IsInCombat() {
     sk := p.Class.GetSkill(words[0])
     if sk != nil {
-      p.CmbSkill = sk
+      p.SetCmbSkill(sk)
       p.SendMsg(fmt.Sprintf("Preparing %s", sk.Name))
       return
     }


### PR DESCRIPTION
* Combat skills are cleared each CombatInstance loop, preventing a skill from being triggered multiple times with only one input
* Setting a character's combat skill requires a lock, which can be set manually.

The combat skill setting lock is locked when a combat loop starts and unlocked at the end.